### PR TITLE
use relative path to image in README

### DIFF
--- a/teal-tiled/README.md
+++ b/teal-tiled/README.md
@@ -1,5 +1,5 @@
 # Front
-![Front](https://github.com/robjweiss/anki-templates/blob/master/src/teal-tiled/front.png)
+![Front](samples/front.png)
 
 # Back
-![Back](https://github.com/robjweiss/anki-templates/blob/master/src/teal-tiled/back.png)
+![Back](samples/back.png)


### PR DESCRIPTION
- Use [GitHub relative paths](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-readmes#relative-links-and-image-paths-in-readme-files) to images in README